### PR TITLE
[Xd] fix: XD上で展開されているLinkedElementもインポート時にまとめて1枚の画像にしてしまっていたのを修正

### DIFF
--- a/Assets/AkyuiUnity.Xd/Editor/Libraries/XdParser/XdParser.cs
+++ b/Assets/AkyuiUnity.Xd/Editor/Libraries/XdParser/XdParser.cs
@@ -643,6 +643,9 @@ namespace XdParser.Internal
 
         [DataMember(Name = "linkedElementLastModified")]
         public ulong? LinkedElementLastModified { get; set; }
+
+        [DataMember(Name = "linkedElementWasImported")]
+        public bool LinkedElementWasImported { get; set; }
     }
 
     public class XdClipPathResourcesJson

--- a/Assets/AkyuiUnity.Xd/Editor/XdGroupParser/SvgGroupParser.cs
+++ b/Assets/AkyuiUnity.Xd/Editor/XdGroupParser/SvgGroupParser.cs
@@ -15,7 +15,7 @@ namespace AkyuiUnity.Xd
             var isLinkedElement = new[] { xdObject }.Concat(parents).Any(x =>
             {
                 var hasParameter = x.HasParameter("vector");
-                var isLinkedElementRef = !string.IsNullOrWhiteSpace(x.Meta?.Ux?.LinkedElementRef);
+                var isLinkedElementRef = !string.IsNullOrWhiteSpace(x.Meta?.Ux?.LinkedElementRef) && x.Meta?.Ux?.LinkedElementWasImported == false;
                 return hasParameter || isLinkedElementRef;
             });
 


### PR DESCRIPTION
こういうXD上では展開されないLinkedElementは1枚の画像にしてしまって、
<img width="318" alt="Screen Shot 2021-04-20 at 8 31 48" src="https://user-images.githubusercontent.com/961165/115315713-db464c00-a1b2-11eb-8a07-ff7c96b03bc7.png">

こういうXD上で展開されるLinkedElementはそのままにする。
<img width="312" alt="Screen Shot 2021-04-20 at 8 32 24" src="https://user-images.githubusercontent.com/961165/115315759-f022df80-a1b2-11eb-8c7f-54d50e2c00ea.png">