### PR TITLE
[Xd] fix: XD上で展開されているLinkedElementもインポート時にまとめて1枚の画像にしてしまっていたのを修正2

### DIFF
--- a/Assets/AkyuiUnity.Xd/Editor/Libraries/XdParser/XdParser.cs
+++ b/Assets/AkyuiUnity.Xd/Editor/Libraries/XdParser/XdParser.cs
@@ -646,6 +646,9 @@ namespace XdParser.Internal
 
         [DataMember(Name = "linkedElementWasImported")]
         public bool LinkedElementWasImported { get; set; }
+
+        [DataMember(Name = "listViewPosition")]
+        public int? ListViewPosition { get; set; }
     }
 
     public class XdClipPathResourcesJson

--- a/Assets/AkyuiUnity.Xd/Editor/XdGroupParser/SvgGroupParser.cs
+++ b/Assets/AkyuiUnity.Xd/Editor/XdGroupParser/SvgGroupParser.cs
@@ -15,7 +15,7 @@ namespace AkyuiUnity.Xd
             var isLinkedElement = new[] { xdObject }.Concat(parents).Any(x =>
             {
                 var hasParameter = x.HasParameter("vector");
-                var isLinkedElementRef = !string.IsNullOrWhiteSpace(x.Meta?.Ux?.LinkedElementRef) && x.Meta?.Ux?.LinkedElementWasImported == false;
+                var isLinkedElementRef = !string.IsNullOrWhiteSpace(x.Meta?.Ux?.LinkedElementRef) && x.Meta?.Ux?.ListViewPosition == null;
                 return hasParameter || isLinkedElementRef;
             });
 


### PR DESCRIPTION
#19 でダメなパターンがあったので再度見直し。

---

## 展開されるべきデータ1

```
{
   "type":"group",
   "name":"Component 1 – 1",
   "meta":{
      "ux":{
         "nameL10N":"SHAPE_COMPONENT",
         "linkedElementRef":"https://cc-api-storage.adobe.io/id/urn:aaid:sc:AP:d2b591b9-f2d0-40a2-a95b-d479f1f5e582",
         "resolvedRefName":"TestComponent",
         "linkedElementWasImported":true,
         "symbolId":"1746f471-4d6f-4914-beb1-8ad565379253",
         "width":206,
         "height":218,
         "componentType":"componentNoBounds",
         "syncMap":{
            "16a7373b-009a-41ab-8c7c-4d9edeb95852":"07795237-425d-47d9-a324-11c85a1435e6",
            "782c8765-5488-443a-9b42-e8bf565c2cc4":"2bdb9761-5c89-4a35-bdff-f370cf36ad4b"
         },
         "listViewPosition":0,
         "assetGroupData":{
            "groupComponents":"h"
         },
         "localTransform":{
            "a":1,
            "b":0,
            "c":0,
            "d":1,
            "tx":92,
            "ty":139
         }
      }
   },
   "id":"29a261f3-be93-40de-953f-93c9245c87fa",
   "transform":{
      "a":1,
      "b":0,
      "c":0,
      "d":1,
      "tx":92,
      "ty":139
   },
   "group":{
      "children":[
         {
            "type":"syncRef",
            "syncSourceGuid":"16a7373b-009a-41ab-8c7c-4d9edeb95852",
            "guid":"07795237-425d-47d9-a324-11c85a1435e6"
         },
         {
            "type":"syncRef",
            "syncSourceGuid":"782c8765-5488-443a-9b42-e8bf565c2cc4",
            "guid":"2bdb9761-5c89-4a35-bdff-f370cf36ad4b"
         }
      ]
   }
}
```

## 展開されるべきデータ2

```
{
   "type":"group",
   "name":"Component 1",
   "meta":{
      "ux":{
         "hasCustomName":true,
         "linkedElementRef":"cloud-asset://cc-api-storage.adobe.io/assets/adobe-libraries/6180d4cf-ed00-4496-bbff-3b081ff03191;node=088d9527-3a9a-49c7-8393-7d01e28026b7",
         "linkedElementBookmarkRef":"{\"assetId\":\"urn:aaid:sc:AP:2dc348ab-f598-4f0a-a156-439889404369\",\"libraryId\":\"6180d4cf-ed00-4496-bbff-3b081ff03191\"}",
         "linkedElementLastModified":1618996080290,
         "symbolId":"1746f471-4d6f-4914-beb1-8ad565379253",
         "width":206,
         "height":218,
         "componentType":"componentNoBounds",
         "syncMap":{
            "16a7373b-009a-41ab-8c7c-4d9edeb95852":"ea49bc3e-d0a6-4527-8d88-19867be3a486",
            "782c8765-5488-443a-9b42-e8bf565c2cc4":"8c8993cf-4a2c-40b4-849c-b090c447deb0"
         },
         "isCustomNameInherited":true,
         "listViewPosition":0,
         "assetGroupData":{
            "groupComponents":"h"
         },
         "localTransform":{
            "a":1,
            "b":0,
            "c":0,
            "d":1,
            "tx":98,
            "ty":135
         }
      }
   },
   "group":{
      "children":[
         {
            "type":"syncRef",
            "syncSourceGuid":"16a7373b-009a-41ab-8c7c-4d9edeb95852",
            "guid":"ea49bc3e-d0a6-4527-8d88-19867be3a486"
         },
         {
            "type":"syncRef",
            "syncSourceGuid":"782c8765-5488-443a-9b42-e8bf565c2cc4",
            "guid":"8c8993cf-4a2c-40b4-849c-b090c447deb0"
         }
      ]
   }
}
```

## 展開しちゃいけないデータ

```
"id": "dd5632dd-f6bc-4a35-95fc-20edda3f32fc",
"meta": {
  "ux": {
    "aspectLock": {
      "height": 793,
      "width": 564.300048828125
    },
    "hasCustomName": true,
    "linkedContentScale": {
      "x": 1,
      "y": 1
    },
    "linkedElementLastModified": 1618874040586,
    "linkedElementRef": "cloud-asset://cc-api-storage.adobe.io/assets/adobe-libraries/e5df4e33-bd64-4b0c-89e4-419b94699ade;node=d30a1641-ee71-437d-8011-9231eb8fc3a1",
    "localTransform": {
      "a": 1,
      "b": 0,
      "c": 0,
      "d": 1,
      "tx": 297.1500244140625,
      "ty": 500.5
    }
  }
},
"name": "1P_guide",
"transform": {
  "a": 1,
  "b": 0,
  "c": 0,
  "d": 1,
  "tx": 297.1500244140625,
  "ty": 500.5
},
"type": "group"
```

## 展開しちゃいけないデータ → 展開するデータ

```
diff --git a/tmp/artwork/artboard-3e573fe9-be1e-4e34-8d03-5f2a7c84283c/graphics/graphicContent.agc b/tmp/artwork/artboard-3e573fe9-be1e-4e34-8d03-5f2a7c84283c/graphics/graphicContent.agc
index aba3d90..dd7671b 100644
--- a/tmp/artwork/artboard-3e573fe9-be1e-4e34-8d03-5f2a7c84283c/graphics/graphicContent.agc
+++ b/tmp/artwork/artboard-3e573fe9-be1e-4e34-8d03-5f2a7c84283c/graphics/graphicContent.agc
@@ -4599,12 +4599,6 @@
                   "width": 564.300048828125
                 },
                 "hasCustomName": true,
-                "linkedContentScale": {
-                  "x": 1,
-                  "y": 1
-                },
-                "linkedElementLastModified": 1618874040586,
-                "linkedElementRef": "cloud-asset://cc-api-storage.adobe.io/assets/adobe-libraries/e5df4e33-bd64-4b0c-89e4-419b94699ade;node=d30a1641-ee71-437d-8011-9231eb8fc3a1",
                 "localTransform": {
                   "a": 1,
                   "b": 0,
```