### PR TITLE
Unity 2022.2 からビルトインフォントの名前が変わりました

### DIFF
--- a/Assets/AkyuiUnity.Xd/Editor/XdObjectParser/TextObjectParser.cs
+++ b/Assets/AkyuiUnity.Xd/Editor/XdObjectParser/TextObjectParser.cs
@@ -68,7 +68,11 @@ namespace AkyuiUnity.Xd
             if (fontAsset == null)
             {
                 XdImporter.Logger.Warning($"{font.PostscriptName} is not found in project / name: {xdObject.Name}, text: {rawText}");
+#if UNITY_2022_2_OR_NEWER
+                fontAsset = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+#else
                 fontAsset = Resources.GetBuiltinResource<Font>("Arial.ttf");
+#endif
             }
             var settings = new TextGenerationSettings
             {

--- a/Assets/AkyuiUnity/Loader/Generator/InternalTrigger/DefaultGenerateTrigger.cs
+++ b/Assets/AkyuiUnity/Loader/Generator/InternalTrigger/DefaultGenerateTrigger.cs
@@ -349,7 +349,11 @@ namespace AkyuiUnity.Generator.InternalTrigger
                 text.font = assetLoader.LoadFont(textComponent.Font);
                 if (text.font == null)
                 {
+#if UNITY_2022_2_OR_NEWER
+                    text.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+#else
                     text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+#endif
                 }
             }
 


### PR DESCRIPTION
https://unity.com/releases/editor/beta/2022.2.0b3#:~:text=Text%3A%20Renamed%20the%20runtime%20default%20resource%20Arial.ttf%20to%20LegacyRuntime.tff.

> Text: Renamed the runtime default resource Arial.ttf to LegacyRuntime.tff.

Unity 2022.2.0b3 からビルトインフォントが Arial.ttf から LegacyRuntime.ttf に変更されているため、 バージョンに応じて参照先が切り替わるように変更いたしました。